### PR TITLE
move code around once more to allow build with latest Go

### DIFF
--- a/cmd/semanticizest-dumpparser/main.go
+++ b/cmd/semanticizest-dumpparser/main.go
@@ -7,7 +7,7 @@
 package main
 
 import (
-	"github.com/semanticize/st/cmd/semanticizest-dumpparser/internal"
+	"github.com/semanticize/st/internal/dumpparser"
 	"github.com/semanticize/st/storage"
 	"gopkg.in/alecthomas/kingpin.v1"
 	"log"
@@ -38,6 +38,6 @@ var (
 func main() {
 	kingpin.Parse()
 
-	internal.Main(*dbpath, *dumppath, *download, *nrows, *ncols, *maxNGram,
+	dumpparser.Main(*dbpath, *dumppath, *download, *nrows, *ncols, *maxNGram,
 		log.New(os.Stderr, "dumpparser ", log.Ldate | log.Ltime))
 }

--- a/internal/dumpparser/main.go
+++ b/internal/dumpparser/main.go
@@ -1,10 +1,6 @@
-// Semanticizer, STandalone: parser for Wikipedia database dumps.
-//
-// Takes a Wikipedia database dump (or downloads one automatically) and
-// produces a model for use by the semanticizest program/web server.
-//
-// Run with --help for command-line usage.
-package internal
+// Guts of semanticizest-dumpparser, extracted into a module for end-to-end
+// testing.
+package dumpparser
 
 import (
 	"bufio"

--- a/internal/dumpparser/main_test.go
+++ b/internal/dumpparser/main_test.go
@@ -1,4 +1,4 @@
-package internal
+package dumpparser
 
 import (
 	"github.com/semanticize/st/storage"

--- a/linking/semanticizer_test.go
+++ b/linking/semanticizer_test.go
@@ -2,7 +2,7 @@ package linking
 
 import (
 	"encoding/json"
-	dumpparser "github.com/semanticize/st/cmd/semanticizest-dumpparser/internal"
+	dumpparser "github.com/semanticize/st/internal/dumpparser"
 	"github.com/semanticize/st/hash"
 	"github.com/semanticize/st/hash/countmin"
 	"github.com/semanticize/st/storage"


### PR DESCRIPTION
Next release of Go will introduce rules for packages called "internal".
Also, this makes the import paths quite a bit shorter.

PR to check if this works with Travis-CI.
