### PR TITLE
allow Travis to fail on go tip

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,4 +3,8 @@ language: go
 go:
   - 1.2
   - 1.3
+  - 1.4
   - tip
+matrix:
+  allow_failures:
+    - go: tip


### PR DESCRIPTION
Current Go tip refuses to compile SQLite bindings:

```
import "C": import path does not begin with hostname
```
