### PR TITLE
Allow Travis build with Go 1.2 to fail

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,5 @@ go:
   - tip
 matrix:
   allow_failures:
+    - go: 1.2
     - go: tip


### PR DESCRIPTION
Looks like go-sqlite doesn't like 1.2 anymore.
